### PR TITLE
Correct filename in library.properties includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ paragraph=Motion detection without bells and whistles, simply works, low power.
 category=Sensors
 url=https://github.com/ldab/lis3dh-motion-detection
 architectures=*
-includes=LIS3DH motion detection.h
+includes=lis3dh-motion-detection.h


### PR DESCRIPTION
The `includes` field in library.properties is used to add an `#include` directive to the sketch via **Sketch > Include Library > LIS3DH motion detection**. The incorrect filename caused compilation to fail:
```
error: LIS3DH motion detection.h: No such file or directory

 #include <LIS3DH motion detection.h>

          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```