### PR TITLE
New functions: readTemperature and disconnectPullup.

### DIFF
--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -13,8 +13,8 @@ Distributed as-is; no warranty is given.
 ******************************************************************************/
 
 // Accelerometer provides different Power modes by changing output bit resolution
-//#define LOW_POWER
-#define NORMAL_MODE
+#define LOW_POWER
+//#define NORMAL_MODE
 //#define HIGH_RESOLUTION
 
 // Enable Serial debbug on Serial UART to see registers wrote
@@ -27,32 +27,37 @@ uint16_t sampleRate = 1;  // HZ - Samples per second - 1, 10, 25, 50, 100, 200, 
 uint8_t accelRange = 2;   // Accelerometer range = 2, 4, 8, 16g
 
 uint16_t errorsAndWarnings = 0;
+#ifdef LOW_POWER
+int8_t tempCalibrate = 25; //  calibrate your LIS3DH
+#else
+int16_t tempCalibrate = 25; //  calibrate your LIS3DH
+#endif
 
-LIS3DH myIMU(0x19); //Default address is 0x19.
+LIS3DH myIMU(0x19); //Default address is 0x19. Adafruit is 0x18
 
 void setup() {
+
+  uint8_t readData = 0;
+  
   // put your setup code here, to run once:
   
   Serial.begin(115200);
-  delay(1000); //wait until serial is open...
+  delay(2000); //wait until serial is open...
   
-  if( myIMU.begin(sampleRate, 1, 1, 1, accelRange) != 0 )
+  while ( myIMU.begin(sampleRate, 1, 1, 1, accelRange) != 0 )
   {
-    Serial.print("Failed to initialize IMU.\n");
+    Serial.print("Failed to initialize IMU. Retry in 3 seconds.\n");
+    delay(3000);
   }
-  else
-  {
-    Serial.print("IMU initialized.\n");
-  }
+  
+  Serial.print("IMU initialized.\n");
   
   //Detection threshold can be from 1 to 127 and depends on the Range
   //chosen above, change it and test accordingly to your application
   //Duration = timeDur x Seconds / sampleRate
   myIMU.intConf(INT_1, DET_MOVE, 13, 2);
   myIMU.intConf(INT_2, DET_STOP, 13, 10, 1);  // also change the polarity to active-low, this will change both Interrupts behavior
-
-  uint8_t readData = 0;
-
+  
   // Confirm configuration:
   myIMU.readRegister(&readData, LIS3DH_INT1_CFG);
   myIMU.readRegister(&readData, LIS3DH_INT2_CFG);
@@ -61,6 +66,8 @@ void setup() {
   myIMU.readRegister(&readData, LIS3DH_WHO_AM_I);
   Serial.print("Who am I? 0x");
   Serial.println(readData, HEX);
+
+  myIMU.temperatureEnable(1);
 
 }
 
@@ -96,6 +103,20 @@ void loop()
   Serial.print(" Acceleration Z float = ");
   Serial.println( myIMU.axisAccel( Z ), 4);
 
-  delay(1000);
+  // Read temperature - need to calibrate.
+  Serial.print(" Temperature = ");
+  #ifdef LOW_POWER
+  Serial.println( tempCalibrate + (int8_t) myIMU.readTemperature());
+  #else
+  int16_t tempTemp;
+  tempTemp = (int16_t) myIMU.readTemperature();
+  Serial.println( tempTemp + tempCalibrate );
+  Serial.print("BIN : ");
+  Serial.print( tempTemp & 0xFF, BIN);
+  Serial.print("\t");
+  Serial.println( tempTemp >> 8, BIN);
+  #endif
+
+  delay(3000); // every second temperature is sometimes erratic.
 
 }

--- a/src/lis3dh-motion-detection.h
+++ b/src/lis3dh-motion-detection.h
@@ -15,6 +15,12 @@ Distributed as-is; no warranty is given.
 #ifndef __LIS3DH_IMU_H__
 #define __LIS3DH_IMU_H__
 
+// Temperature works only if I define LOW_POWER here (!).
+// Tested with arduino, not with platformio
+#if !defined LOW_POWER & !defined NORMAL_MODE & !defined HIGH_RESOLUTION
+#define LOW_POWER
+#endif
+
 #include "stdint.h"
 
 #if defined(ARDUINO) && ARDUINO >= 100
@@ -119,6 +125,13 @@ public:
 	float axisAccel( axis_t _axis);
 	uint8_t readClick();
 	uint8_t readAxisEvents();
+	#ifdef LOW_POWER
+	int8_t  readTemperature();
+	#else
+	int16_t readTemperature();
+	#endif
+
+	void temperatureEnable(bool command);
 
 	// timeLimit is 7bit
 	void clickConf (bool Zdouble = 1, bool Zsingle = 1, bool Ydouble = 1, bool Ysingle = 1,
@@ -130,6 +143,7 @@ public:
 
 	// Set the IMU to Power-down mode ~ 0.5uA;
 	imu_status_t imu_power_down( void );
+	void disconnectPullUp(bool command);
 	
 private:
 	uint8_t I2CAddress;
@@ -151,6 +165,7 @@ private:
 #define LIS3DH_STATUS_REG_AUX         0x07
 #define LIS3DH_WHO_AM_I               0x0F
 
+#define LIS3DH_CTRL_REG0              0x1E
 #define LIS3DH_CTRL_REG1              0x20
 #define LIS3DH_CTRL_REG2              0x21
 #define LIS3DH_CTRL_REG3              0x22
@@ -187,5 +202,12 @@ private:
 #define LIS3DH_ACT_DUR                0x3F
 
 #define LIS3DH_TEMP_CFG_REG           0x1F
+
+#define LIS3DH_OUT_ADC1_L		0x08
+#define LIS3DH_OUT_ADC1_H		0x09
+#define LIS3DH_OUT_ADC2_L		0x0A
+#define LIS3DH_OUT_ADC2_H		0x0B
+#define LIS3DH_OUT_ADC3_L		0x0C
+#define LIS3DH_OUT_ADC3_H		0x0D
 
 #endif // End of __LIS3DH_IMU_H__ definition check


### PR DESCRIPTION
Hello there.

Now you can save 0.135 mA with `disconnectPullup(1)`  and you have a pretty good temperature sensor with `readTemperature()` but you need to calibrate it.

`readTemperature` function is weird. I was unable to read the register unless I re-apply the settings.
https://github.com/clavisound/lis3dh-motion-detection/blob/17625f6f164e2e79384d5c8d5e3753b3fc2f2383/src/lis3dh-motion-detection.cpp#L493

Also one strange thing. I needed to define `LOW_POWER` and other modes on library. If they are defined in arduino sketch `readTemperature()` does not work (!).
https://github.com/clavisound/lis3dh-motion-detection/blob/17625f6f164e2e79384d5c8d5e3753b3fc2f2383/src/lis3dh-motion-detection.h#L18