### PR TITLE
readTemperature BUG fix

### DIFF
--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -105,17 +105,7 @@ void loop()
 
   // Read temperature - need to calibrate.
   Serial.print(" Temperature = ");
-  #ifdef LOW_POWER
   Serial.println( tempCalibrate + (int8_t) myIMU.readTemperature());
-  #else
-  int16_t tempTemp;
-  tempTemp = (int16_t) myIMU.readTemperature();
-  Serial.println( tempTemp + tempCalibrate );
-  Serial.print("BIN : ");
-  Serial.print( tempTemp & 0xFF, BIN);
-  Serial.print("\t");
-  Serial.println( tempTemp >> 8, BIN);
-  #endif
 
   delay(3000); // every second temperature is sometimes erratic.
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "LIS3DH motion detection",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Motion detection without bells and whistles, simply works, low power",
     "keywords": "sensors, accelerometer, motion detection, motion detector, low power, mobile, battery, web, cloud, iot, gsm, gprs, gps, gnss",
     "authors":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LIS3DH motion detection
-version=0.0.6
+version=0.0.7
 author=Leonardo Bispo
 license=MIT
 maintainer=Leonardo Bispo <l.bispo@live.com>

--- a/src/lis3dh-motion-detection.cpp
+++ b/src/lis3dh-motion-detection.cpp
@@ -99,7 +99,7 @@ imu_status_t LIS3DH::readRegisterRegion(uint8_t *outputPointer , uint8_t offset,
   }
   else  //OK, all worked, keep going
   {
-    // request 6 bytes from slave device
+    // request length bytes from slave device
     Wire.requestFrom(I2CAddress, length);
     while ( (Wire.available()) && (i < length))  // slave may send less than requested
     {
@@ -158,7 +158,6 @@ imu_status_t LIS3DH::readRegister(uint8_t* outputPointer, uint8_t offset) {
 imu_status_t LIS3DH::readRegisterInt16( int16_t* outputPointer, uint8_t offset )
 {
 	{
-		//offset |= 0x80; //turn auto-increment bit on
 		uint8_t myBuffer[2];
 		imu_status_t returnError = readRegisterRegion(myBuffer, offset, 2);  //Does memory transfer
 		int16_t output = (int16_t)myBuffer[0] | int16_t(myBuffer[1] << 8);
@@ -485,8 +484,7 @@ void LIS3DH::temperatureEnable(bool command){
 	}
 }
 
-// Only in low power we have 8bit. Otherwise 10bit
-#ifdef LOW_POWER
+// 8bits in all modes
 int8_t  LIS3DH::readTemperature(){
 	uint8_t r;
 
@@ -494,8 +492,8 @@ int8_t  LIS3DH::readTemperature(){
 					// re-run to re-apply settings. Otherwise
 					// the temperature report is always the same.
 	
-	// do we have data?
 	readRegister(&r, LIS3DH_STATUS_REG_AUX);
+	// check if we have data
 	if ( ( r & 0x04 ) == 0x04 ) {
 		readRegister(&r, LIS3DH_OUT_ADC3_H); // here are the data
 		return (int8_t) r;
@@ -503,23 +501,6 @@ int8_t  LIS3DH::readTemperature(){
 	// we don't have data. Return deep freezing for error.
 	return 0xFF;
 }
-#else
-// 10 bit value, UNTESTED
-int16_t LIS3DH::readTemperature(){
-	int16_t r;
-	
-	temperatureEnable(1);		// Read comment above
-
-	// do we have data?
-	readRegisterInt16(&r, LIS3DH_STATUS_REG_AUX);
-	if ( ( r & 0x04 ) == 0x04 ) {
-		readRegisterInt16(&r, LIS3DH_OUT_ADC3_L);
-		return (int16_t) r;
-	}
-	// we don't have data. Return deep freezing for error.
-	return 0xFFFF;
-}
-#endif
 
 // disconnect pullup on SDO/SA for lower power consumption
 void LIS3DH::disconnectPullUp(bool command){

--- a/src/lis3dh-motion-detection.h
+++ b/src/lis3dh-motion-detection.h
@@ -15,12 +15,6 @@ Distributed as-is; no warranty is given.
 #ifndef __LIS3DH_IMU_H__
 #define __LIS3DH_IMU_H__
 
-// Temperature works only if I define LOW_POWER here (!).
-// Tested with arduino, not with platformio
-#if !defined LOW_POWER & !defined NORMAL_MODE & !defined HIGH_RESOLUTION
-#define LOW_POWER
-#endif
-
 #include "stdint.h"
 
 #if defined(ARDUINO) && ARDUINO >= 100
@@ -125,11 +119,7 @@ public:
 	float axisAccel( axis_t _axis);
 	uint8_t readClick();
 	uint8_t readAxisEvents();
-	#ifdef LOW_POWER
 	int8_t  readTemperature();
-	#else
-	int16_t readTemperature();
-	#endif
 
 	void temperatureEnable(bool command);
 
@@ -170,7 +160,7 @@ private:
 #define LIS3DH_CTRL_REG2              0x21
 #define LIS3DH_CTRL_REG3              0x22
 #define LIS3DH_CTRL_REG4              0x23
-#define LIS3DH_CTRL_REG5              0x24 //not included
+#define LIS3DH_CTRL_REG5              0x24
 #define LIS3DH_CTRL_REG6              0x25
 #define LIS3DH_REFERENCE              0x26
 #define LIS3DH_STATUS_REG2            0x27


### PR DESCRIPTION
`readTemperature` was working only on `LOW_POWER` because I had the impression that it's 10bits on other modes and 8bits on `LOW_POWER`. It's 8bit on all modes. Corrected. Now `readTemperature` works on all modes: `LOW_POWER`, `NORMAL_MODE`, `HIGH_RESOLUTION`.

I had `#define LOW_POWER` for no reason. Removed from Basic.ino example and from library.

Have a nice day!